### PR TITLE
feat: Trial using Vercel Analytics

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+* @brianespinosa

--- a/apps/branches/app/layout.tsx
+++ b/apps/branches/app/layout.tsx
@@ -1,3 +1,5 @@
+import { Analytics } from '@vercel/analytics/react';
+
 export default function RootLayout({
   children,
 }: {
@@ -6,6 +8,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body>{children}</body>
+      <Analytics />
     </html>
   );
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@ariakit/react": "0.3.3",
     "@nx/devkit": "16.10.0",
     "@swc/helpers": "~0.5.2",
+    "@vercel/analytics": "1.3.1",
     "@vercel/og": "0.6.2",
     "clsx": "2.0.0",
     "core-js": "3.33.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -104,6 +104,7 @@ __metadata:
     "@types/svg2png": 4.1.3
     "@typescript-eslint/eslint-plugin": 5.62.0
     "@typescript-eslint/parser": 5.62.0
+    "@vercel/analytics": 1.3.1
     "@vercel/og": 0.6.2
     "@vercel/remote-nx": 1.1.1
     babel-jest: 29.6.2
@@ -4689,6 +4690,23 @@ __metadata:
     "@typescript-eslint/types": 5.62.0
     eslint-visitor-keys: ^3.3.0
   checksum: 976b05d103fe8335bef5c93ad3f76d781e3ce50329c0243ee0f00c0fcfb186c81df50e64bfdd34970148113f8ade90887f53e3c4938183afba830b4ba8e30a35
+  languageName: node
+  linkType: hard
+
+"@vercel/analytics@npm:1.3.1":
+  version: 1.3.1
+  resolution: "@vercel/analytics@npm:1.3.1"
+  dependencies:
+    server-only: ^0.0.1
+  peerDependencies:
+    next: ">= 13"
+    react: ^18 || ^19
+  peerDependenciesMeta:
+    next:
+      optional: true
+    react:
+      optional: true
+  checksum: 5f052793fc19548ee9fac05c52f6effba3b3a5b2cd6b734f63a8c98e2a79e72f4059d01625995f5a8c790a5f55c717ebd25db600eda1358e3d270c9c90597e88
   languageName: node
   linkType: hard
 
@@ -13781,6 +13799,13 @@ __metadata:
     parseurl: ~1.3.3
     send: 0.18.0
   checksum: af57fc13be40d90a12562e98c0b7855cf6e8bd4c107fe9a45c212bf023058d54a1871b1c89511c3958f70626fff47faeb795f5d83f8cf88514dbaeb2b724464d
+  languageName: node
+  linkType: hard
+
+"server-only@npm:^0.0.1":
+  version: 0.0.1
+  resolution: "server-only@npm:0.0.1"
+  checksum: c432348956641ea3f460af8dc3765f3a1bdbcf7a1e0205b0756d868e6e6fe8934cdee6bff68401a1dd49ba4a831c75916517a877446d54b334f7de36fa273e53
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Trial using Vercel analytics alongside the existing Fathom tool.

Need to see if there is a way to break down traffic by tenant. If so, it could be valuable to give branch managers to a dashboard showing their own microsite traffic. Vercel supplies APIs that might allow this.