### PR TITLE
fix: fixtures should render date on client

### DIFF
--- a/libs/components/src/lib/FixtureCard/FixtureCard.tsx
+++ b/libs/components/src/lib/FixtureCard/FixtureCard.tsx
@@ -1,3 +1,5 @@
+'use client'; // Needed because we are dealing with dates relative to the user. We can move this to the game info section later on to encapsulate the date
+
 import styles from './FixtureCard.module.scss';
 
 import Image from 'next/image';


### PR DESCRIPTION
If the server is in a different time zone than the client, the date will be relative to the server, which will give an incorrect time. We need to make sure dates are rendered on the client with the `use client` directive.