### PR TITLE
feat: improve live game details on home page

### DIFF
--- a/apps/api/app/fixtures/next/route.ts
+++ b/apps/api/app/fixtures/next/route.ts
@@ -8,7 +8,7 @@ import logger from '../../logger';
 const USA_COUNTRY_ID = 3483;
 
 // https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#revalidate
-export const revalidate = 60 * 60; // 1 hour
+export const revalidate = 30; // 30 seconds
 
 export async function GET() {
   try {

--- a/apps/api/app/fixtures/route.ts
+++ b/apps/api/app/fixtures/route.ts
@@ -6,7 +6,7 @@ import { season } from '@arsenalamerica/utils';
 import logger from '../logger';
 
 // https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#revalidate
-export const revalidate = 60 * 60; // 1 hour
+export const revalidate = 3600; // 1 hour
 
 export async function GET() {
   try {

--- a/apps/api/app/standings/route.ts
+++ b/apps/api/app/standings/route.ts
@@ -7,6 +7,9 @@ import logger from '../logger';
 // This League ID is for the Premier League and we can use it to make the table live results once the season starts
 // const LEAGUE_ID = 8;
 
+// https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#revalidate
+export const revalidate = 1800; // 30 minutes
+
 export async function GET() {
   try {
     const { data, ...rest } = await smStandings(undefined, {

--- a/apps/api/next.config.js
+++ b/apps/api/next.config.js
@@ -8,6 +8,11 @@ const { composePlugins, withNx } = require('@nx/next');
  **/
 const nextConfig = {
   poweredByHeader: false,
+  logging: {
+    fetches: {
+      fullUrl: true,
+    },
+  },
 };
 
 const plugins = [

--- a/apps/branches/app/[domain]/page.tsx
+++ b/apps/branches/app/[domain]/page.tsx
@@ -14,7 +14,7 @@ export interface HomeProps {
 }
 
 // https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#revalidate
-export const revalidate = 60; // 15 minutes
+export const revalidate = 45; // 45 seconds
 
 export default async function Home({ params }: { params: { domain: string } }) {
   const branch = branchData[params.domain];

--- a/libs/components/src/lib/FixtureCard/FixtureCard.tsx
+++ b/libs/components/src/lib/FixtureCard/FixtureCard.tsx
@@ -65,7 +65,7 @@ export function FixtureCard({
           {localTeam && <FixtureCardTeam {...localTeam} />}
           <div className={styles.Separator}>
             <div className={styles.Date}>
-              {isActive ? (ticking ? ticking.minutes : 'HT') : gameDate}
+              {isActive ? (ticking ? ticking.minutes + "'" : 'HT') : gameDate}
             </div>
             <div className={styles.Score}>
               {isFuture

--- a/libs/utils/src/lib/shite.ts
+++ b/libs/utils/src/lib/shite.ts
@@ -3,7 +3,9 @@ export function shite(text: string) {
     .replace('Tottenham', 'Totnum')
     .replace('tottenham', 'totnum')
     .replace('hotspur', 'shitspur')
-    .replace('Hotspur', 'Shitspur');
+    .replace('Hotspur', 'Shitspur')
+    .replace('(London)', '')
+    .trim();
 
   return shite;
 }


### PR DESCRIPTION
Resolves #64 

Technically, dynamic caching rules cannot be applied on one endpoint, but there may be a way to have a control endpoint with no cache that can switch between returning calls from a hard cached endpoint, and a low cached endpoint… and when a result is done, it could also invalidate the cache on the static endpoint.

Unless Nextjs adds information about the cache duration in the response where this could be done all from one endpoint.

