### PR TITLE
feat: control for some bad actors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,7 @@ updates:
     rebase-strategy: 'auto'
     directory: '/'
     schedule:
-      interval: 'daily'
-    assignees:
-      - 'brianespinosa'
+      interval: 'weekly'
     ignore:
       # Ignore updates to anything related to NX, as those updates should be run by hand.
       - dependency-name: '@nrwl*'

--- a/apps/branches/middleware.ts
+++ b/apps/branches/middleware.ts
@@ -4,8 +4,29 @@ import { branches } from '@arsenalamerica/data';
 
 const DOMAINS = Object.keys(branches);
 
+const BAD_ACTORS = [
+  '.asp',
+  '.aspx',
+  '.env',
+  '.php',
+  '/admin',
+  '/login',
+  'wp-admin',
+  'wp-content',
+  'wp-includes',
+  'wp-json',
+  'wp-login',
+];
+
 export function middleware(request: NextRequest) {
   const url = request.nextUrl;
+
+  // First, check for bad actors, and rewrite them to a local IP address.
+  // Might update this later to automatically set a firewall rule for these IPs:
+  // https://vercel.com/docs/security/vercel-waf/examples#deny-traffic-from-a-set-of-ip-addresses
+  if (BAD_ACTORS.some((bad) => url.pathname.includes(bad))) {
+    return NextResponse.rewrite(new URL('http://192.168.0.250', request.url));
+  }
 
   // Check for local development
   const isLocal = url.hostname === 'localhost';


### PR DESCRIPTION
Based on system logs, we have some idiots who are trying to poke around the apps. This adds for now a rewrite to a local IP to hang any scripts that are being used to test the sites.

This is a test for now to see what sort of impact this has, combined with challenge rules for out of country traffic.

Might eventually also just use a firewall rule to block IPs in this particular scenario.