### PR TITLE
chore: Update CI to not use nx-cloud

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,28 +11,35 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  main:
-    name: Nx Cloud - Main Job
-    uses: nrwl/ci/.github/workflows/nx-cloud-main.yml@v0.15.0
-    secrets: inherit
-    with:
-      main-branch-name: main
-      number-of-agents: 3
-      install-commands: |
-        yarn install --no-immutable
-      init-commands: |
-        yarn nx-cloud start-ci-run --stop-agents-after="test" --agent-count=3
-      # parallel-commands: |
-      #   yarn nx-cloud record -- yarn nx format:check
-      parallel-commands-on-agents: |
-        yarn nx affected --target=lint --parallel=3
-        yarn nx affected --target=test --parallel=3 --ci --code-coverage
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: brianespinosa/checkout-setup-node-install@main
+      - run: yarn nx affected --target=lint --parallel=3
 
-  agents:
-    name: Nx Cloud - Agents
-    uses: nrwl/ci/.github/workflows/nx-cloud-agents.yml@v0.15.0
-    secrets: inherit
-    with:
-      number-of-agents: 3
-      install-commands: |
-        yarn install --no-immutable
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: brianespinosa/checkout-setup-node-install@main
+      - run: yarn nx affected --target=test --parallel=3 --ci
+      # - name: Setup LCOV
+      #   uses: hrishikesh-kadam/setup-lcov@v1
+      # - name: Report code coverage
+      #   uses: zgosalvez/github-actions-report-lcov@v3
+      #   with:
+      #     coverage-files: coverage/**/lcov.info
+      #     minimum-coverage: 90
+      #     artifact-name: code-coverage-report
+      #     github-token: ${{ secrets.GITHUB_TOKEN }}
+      #     working-directory: apps/my-first-app
+      #     update-comment: true
+
+  build:
+    runs-on: ubuntu-latest
+    needs:
+      - lint
+      - test
+    steps:
+      - uses: brianespinosa/checkout-setup-node-install@main
+      - uses: brianespinosa/next-build-cache@main
+      - run: yarn nx affected --target=build --parallel=3

--- a/nx.json
+++ b/nx.json
@@ -4,15 +4,9 @@
     "appsDir": "apps",
     "libsDir": "libs"
   },
+  "neverConnectToCloud": true,
   "tasksRunnerOptions": {
     "default": {
-      "runner": "nx-cloud",
-      "options": {
-        "cacheableOperations": ["build", "lint", "stylelint", "test", "e2e"],
-        "accessToken": "M2NkMjFlNjYtMzQ5Yy00ZGQzLWFiYjgtNWY2Y2RhYWExZTkzfHJlYWQtd3JpdGU="
-      }
-    },
-    "vercel": {
       "runner": "@vercel/remote-nx",
       "options": {
         "cacheableOperations": ["build", "lint", "stylelint", "test", "e2e"]
@@ -31,12 +25,13 @@
       "inputs": ["default", "^production", "{workspaceRoot}/jest.preset.js"],
       "cache": true,
       "options": {
-        "passWithNoTests": true
+        "passWithNoTests": true,
+        "codeCoverage": true,
+        "coverageReporters": ["json", "lcov", "text"]
       },
       "configurations": {
         "ci": {
-          "ci": true,
-          "codeCoverage": true
+          "ci": true
         }
       }
     },


### PR DESCRIPTION
It is too easy, even as a single developer, to blow through NX Cloud credits in just a few days. Can’t have CI grinding to a halt when this happens.